### PR TITLE
Fix SonarQube low issues: document public Promise API

### DIFF
--- a/include/promise/StatePromise.h
+++ b/include/promise/StatePromise.h
@@ -44,11 +44,13 @@ public:
     * @return A promise that resolves when the state promise is ready.
     */
    [[nodiscard]] WPromise<void> WaitReady() const;
+
    /** @brief Waits for the promise to be done.
     *
     * @return A promise that resolves when the state promise is done.
     */
    [[nodiscard]] WPromise<void> WaitDone() const;
+
    /** @brief Waits for the promise to be either ready or done.
     *
     * @return A promise that resolves when the state promise is either ready or done.
@@ -57,8 +59,10 @@ public:
 
    /** @brief Marks the promise as ready. */
    void Ready();
+
    /** @brief Marks the promise as done. */
    void Done();
+
    /** @brief Resets the promise to its initial state, allowing it to be reused. */
    void Reset();
 

--- a/include/promise/core/Handle.h
+++ b/include/promise/core/Handle.h
@@ -46,9 +46,16 @@ namespace promise {
  * This class allows promises to be awaited without knowing their concrete type.
  */
 struct Function {
+   /** @brief Virtual destructor for type erasure. */
    virtual ~Function() = default;
 };
 
+/**
+ * @brief Base coroutine handle implementation used by promise details.
+ *
+ * @tparam T Promise value type.
+ * @tparam WITH_RESOLVER Whether resolution is driven by an external resolver.
+ */
 template <class T, bool WITH_RESOLVER>
 class Handle : public ValuePromise<T> {
 protected:
@@ -144,6 +151,7 @@ protected:
       struct InitSuspend {
          Parent& self_;
 
+         /** @brief Check whether initial suspension can be skipped. */
          [[nodiscard]] constexpr bool await_ready() const noexcept;
 
          /**
@@ -288,15 +296,23 @@ public:
      std::shared_ptr<details::Promise<T, WITH_RESOLVER>>&& self
    ) &&;
 
+   /** @brief Type-erased detach hook used by VPromise. */
    void VDetach() && override;
 
+   /** @brief Destroy the handle and release coroutine state. */
    ~Handle();
 
+   /** @brief Non-movable handle type. */
    Handle(Handle&& rhs) noexcept = delete;
-   Handle(Handle const& rhs)     = delete;
 
+   /** @brief Non-copyable handle type. */
+   Handle(Handle const& rhs) = delete;
+
+   /** @brief Non-movable handle type. */
    Handle& operator=(Handle&& rhs) noexcept = delete;
-   Handle& operator=(Handle const& rhs)     = delete;
+
+   /** @brief Non-copyable handle type. */
+   Handle& operator=(Handle const& rhs) = delete;
 
    /**
     * @brief Check if the coroutine handle is cleared.

--- a/include/promise/core/Promise.h
+++ b/include/promise/core/Promise.h
@@ -76,6 +76,7 @@ class Promise
 #endif  // PROMISE_MEMCHECK
 {
 public:
+   /** @brief Coroutine promise_type produced by this details implementation. */
    using promise_type = Handle<T, WITH_RESOLVER>::PromiseType;
 
 protected:
@@ -108,10 +109,17 @@ public:
     */
    ~Promise() override;
 
-   Promise(Promise&& rhs) noexcept            = delete;
+   /** @brief Non-movable promise details type. */
+   Promise(Promise&& rhs) noexcept = delete;
+
+   /** @brief Non-movable promise details type. */
    Promise& operator=(Promise&& rhs) noexcept = delete;
-   Promise(Promise const&)                    = delete;
-   Promise& operator=(Promise const&)         = delete;
+
+   /** @brief Non-copyable promise details type. */
+   Promise(Promise const&) = delete;
+
+   /** @brief Non-copyable promise details type. */
+   Promise& operator=(Promise const&) = delete;
 
 private:
    /**

--- a/include/promise/core/Reject.h
+++ b/include/promise/core/Reject.h
@@ -44,6 +44,13 @@ private:
    Reject(std::function<void(std::exception_ptr)> impl);
 
 public:
+   /**
+    * @brief Create a shared reject handle.
+    *
+    * @param impl Callback invoked when rejecting.
+    *
+    * @return Shared reject handle.
+    */
    static std::shared_ptr<Reject> Create(std::function<void(std::exception_ptr)> impl);
 
    /**

--- a/include/promise/core/Resolve.h
+++ b/include/promise/core/Resolve.h
@@ -53,6 +53,13 @@ private:
    Resolve(std::shared_ptr<Resolver<void>> resolver);
 
 public:
+   /**
+    * @brief Create a shared resolve handle for Promise<void>.
+    *
+    * @param resolver Shared resolver state.
+    *
+    * @return Shared resolve handle.
+    */
    static std::shared_ptr<Resolve<void>> Create(std::shared_ptr<Resolver<void>> resolver);
 
    /**
@@ -88,6 +95,13 @@ private:
    Resolve(std::shared_ptr<Resolver<T>> resolver);
 
 public:
+   /**
+    * @brief Create a shared resolve handle for Promise<T>.
+    *
+    * @param resolver Shared resolver state.
+    *
+    * @return Shared resolve handle.
+    */
    static std::shared_ptr<Resolve<T>> Create(std::shared_ptr<Resolver<T>> resolver);
 
    /**

--- a/include/promise/core/Resolver.h
+++ b/include/promise/core/Resolver.h
@@ -65,11 +65,17 @@ struct ResolverValue<void> {
    bool value_is_set_{false};
 };
 
+/**
+ * @brief Shared resolver state for Promise<T>.
+ *
+ * @tparam T Promise value type.
+ */
 template <class T>
 class Resolver
    : public std::enable_shared_from_this<Resolver<T>>
    , private ResolverValue<T> {
 public:
+   /** @brief Weak reference to resolver-backed or direct promise state. */
    using Promise = std::
      variant<std::weak_ptr<details::Promise<T, true>>, std::weak_ptr<details::Promise<T, false>>>;
 
@@ -77,8 +83,14 @@ private:
    Resolver() = default;
 
 public:
+   /** @brief Virtual destructor for shared resolver state. */
    virtual ~Resolver() = default;
 
+   /**
+    * @brief Create resolver state and its public resolve/reject handles.
+    *
+    * @return Tuple of resolver state, resolve handle, and reject handle.
+    */
    static constexpr std::
      tuple<std::shared_ptr<Resolver<T>>, std::shared_ptr<Resolve<T>>, std::shared_ptr<Reject>>
      Create();

--- a/include/promise/core/VPromise.h
+++ b/include/promise/core/VPromise.h
@@ -35,22 +35,42 @@ namespace promise {
  */
 class VPromise {
 public:
-   VPromise()                               = default;
-   VPromise(VPromise const&)                = default;
-   VPromise(VPromise&&) noexcept            = default;
-   VPromise& operator=(VPromise const&)     = default;
+   /** @brief Default constructor. */
+   VPromise() = default;
+
+   /** @brief Copy constructor. */
+   VPromise(VPromise const&) = default;
+
+   /** @brief Move constructor. */
+   VPromise(VPromise&&) noexcept = default;
+
+   /** @brief Copy assignment. */
+   VPromise& operator=(VPromise const&) = default;
+
+   /** @brief Move assignment. */
    VPromise& operator=(VPromise&&) noexcept = default;
 
+   /** @brief Virtual destructor for type erasure. */
    virtual ~VPromise() = default;
 
    class Awaitable {
    public:
-      Awaitable()          = default;
+      /** @brief Default constructor. */
+      Awaitable() = default;
+
+      /** @brief Virtual destructor for polymorphic awaitables. */
       virtual ~Awaitable() = default;
 
-      Awaitable(Awaitable const&)                = default;
-      Awaitable& operator=(Awaitable const&)     = default;
-      Awaitable(Awaitable&&) noexcept            = default;
+      /** @brief Copy constructor. */
+      Awaitable(Awaitable const&) = default;
+
+      /** @brief Copy assignment. */
+      Awaitable& operator=(Awaitable const&) = default;
+
+      /** @brief Move constructor. */
+      Awaitable(Awaitable&&) noexcept = default;
+
+      /** @brief Move assignment. */
       Awaitable& operator=(Awaitable&&) noexcept = default;
 
       /**

--- a/include/promise/core/WPromise.h
+++ b/include/promise/core/WPromise.h
@@ -47,25 +47,47 @@ namespace promise::details {
 template <class T>
 class WPromise : public promise::VPromise {
 public:
-   using Promise  = promise::details::Promise<T, false>;
+   /** @brief Promise details type for non-resolver promises. */
+   using Promise = promise::details::Promise<T, false>;
+   /** @brief Promise details type for resolver-backed promises. */
    using RPromise = promise::details::Promise<T, true>;
 
-   using Details     = std::variant<std::shared_ptr<Promise>, std::shared_ptr<RPromise>>;
+   /** @brief Shared variant over non-resolver and resolver-backed details. */
+   using Details = std::variant<std::shared_ptr<Promise>, std::shared_ptr<RPromise>>;
+   /** @brief Promise resolved value type. */
    using return_type = T;
 
-   WPromise(WPromise const& other)                = default;
-   WPromise& operator=(WPromise const& other)     = default;
-   WPromise(WPromise&& other) noexcept            = default;
+   /** @brief Copy constructor. */
+   WPromise(WPromise const& other) = default;
+
+   /** @brief Copy assignment. */
+   WPromise& operator=(WPromise const& other) = default;
+
+   /** @brief Move constructor. */
+   WPromise(WPromise&& other) noexcept = default;
+
+   /** @brief Move assignment. */
    WPromise& operator=(WPromise&& other) noexcept = default;
 
+   /** @brief Destroy this promise handle. */
    ~WPromise();
 
+   /**
+    * @brief Construct a promise handle from a callable.
+    *
+    * @param fun Callable used to create/start the promise.
+    */
    template <class FUN>
       requires(function_constructible<FUN>)
    WPromise(FUN&& fun);
 
    class VAwaitable : public VPromise::Awaitable {
    public:
+      /**
+       * @brief Construct a type-erased awaitable from promise details.
+       *
+       * @param details Shared promise details.
+       */
       explicit VAwaitable(Details details);
 
       /**
@@ -95,6 +117,11 @@ public:
 
    class Awaitable {
    public:
+      /**
+       * @brief Construct an awaitable from promise details.
+       *
+       * @param details Shared promise details.
+       */
       explicit Awaitable(Details details);
 
       /**
@@ -123,7 +150,16 @@ public:
       Details details_;
    };
 
-   Awaitable        operator co_await();
+   /** @brief Build an awaitable adapter for this promise. */
+   Awaitable operator co_await();
+
+   /**
+    * @brief Free-function co_await adapter.
+    *
+    * @param promise Promise to await.
+    *
+    * @return Awaitable adapter over the same shared state.
+    */
    friend Awaitable operator co_await(WPromise const& promise) {
       return Awaitable{promise.details_};
    }
@@ -291,6 +327,11 @@ public:
    template <class EXCEPTION, class... ARGS>
    static constexpr WPromise<T> Reject(ARGS&&... args);
 
+   /**
+    * @brief Create a pending promise with resolve and reject handles.
+    *
+    * @return Tuple of promise handle, resolve handle, and reject handle.
+    */
    static constexpr std::
      tuple<WPromise<T>, std::shared_ptr<promise::Resolve<T>>, std::shared_ptr<promise::Reject>>
      Create();
@@ -354,10 +395,12 @@ private:
    friend class ::promise::details::Promise;
 };
 
+/** @brief Deduction guide for promise-returning callables. */
 template <class FUN>
    requires(function_constructible<FUN> && IS_PROMISE_FUNCTION<FUN>)
 WPromise(FUN&& fun) -> WPromise<return_or_void_t<return_t<FUN>>>;
 
+/** @brief Deduction guide for value-returning callables. */
 template <class FUN>
    requires(function_constructible<FUN> && !IS_PROMISE_FUNCTION<FUN>)
 WPromise(FUN&& fun) -> WPromise<WReturn<FUN>>;
@@ -371,10 +414,14 @@ WPromise(FUN&& fun) -> WPromise<WReturn<FUN>>;
 template <class T, bool WITH_RESOLVER>
 class IPromise : public WPromise<T> {
 public:
-   using Parent       = WPromise<T>;
-   using Details      = promise::details::Promise<T, WITH_RESOLVER>;
-   using promise_type = Details::promise_type;
-   using return_type  = T;
+   /** @brief Parent public promise handle type. */
+   using Parent = WPromise<T>;
+   /** @brief Concrete details type for this resolver mode. */
+   using Details = promise::details::Promise<T, WITH_RESOLVER>;
+   /** @brief Coroutine promise_type associated with this handle. */
+   using promise_type = typename Details::promise_type;
+   /** @brief Promise resolved value type. */
+   using return_type = T;
 
    /**
     * @brief co_await operator for resolver-less promises.

--- a/include/promise/core/core.h
+++ b/include/promise/core/core.h
@@ -53,10 +53,21 @@ template <class... PROMISE>
 static constexpr auto All(PROMISE&&... promise);
 
 namespace details {
+/**
+ * @brief Internal promise details implementation.
+ *
+ * @tparam T Promise value type.
+ * @tparam WITH_RESOLVER Whether the promise is externally resolved.
+ */
 template <class T, bool WITH_RESOLVER = false>
 class Promise;
-}
+}  // namespace details
 
+/**
+ * @brief Shared resolver state used by resolve/reject handles.
+ *
+ * @tparam T Promise value type.
+ */
 template <class T>
 class Resolver;
 }  // namespace promise


### PR DESCRIPTION
## Summary
This PR addresses SonarQube LOW issues in the `promise` project, focused on undocumented public API declarations.

## Branch
- Head: `fix/sonarqube-undocumented-api`
- Base: `master`

## What changed
- Added/expanded API documentation comments across the public core headers.
- Kept fixes documentation-only (no runtime behavior changes).
- Updated documentation for public classes, aliases, constructors/destructors, factory methods, and type-erased interfaces.

## Files touched
- `include/promise/core/Handle.h`
- `include/promise/core/Promise.h`
- `include/promise/core/WPromise.h`
- `include/promise/core/Resolver.h`
- `include/promise/core/Resolve.h`
- `include/promise/core/Reject.h`
- `include/promise/core/VPromise.h`
- `include/promise/core/core.h`

## Validation
- Triggered SonarQube-for-IDE analysis on changed files.
- No functional/codepath changes introduced.