### PR TITLE
Compile-time optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,6 @@ win32_library(TARGET_NAME jsprocpp
   src/Reject.cpp
   src/Resolve.cpp
   src/Promise.cpp
-  src/PromiseExplicitInstantiations.cpp
   src/CVPromise.cpp
   src/Mutex.cpp
   src/StatePromise.cpp

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "test/*"
+  

--- a/include/promise/CVPromise.h
+++ b/include/promise/CVPromise.h
@@ -25,7 +25,6 @@ SOFTWARE.
 #pragma once
 
 #include "Mutex.h"
-#include "core.h"
 
 #include <stdexcept>
 #include <type_traits>

--- a/include/promise/Mutex.h
+++ b/include/promise/Mutex.h
@@ -24,7 +24,6 @@ SOFTWARE.
 
 #pragma once
 
-#include "core/WPromise.h"
 #include "core.h"
 
 #include <shared_mutex>

--- a/include/promise/Pool.h
+++ b/include/promise/Pool.h
@@ -24,7 +24,7 @@ SOFTWARE.
 
 #pragma once
 
-#include "promise.h"
+#include "core.h"
 
 #include <utils/Pool.h>
 #include <optional>

--- a/include/promise/StatePromise.h
+++ b/include/promise/StatePromise.h
@@ -24,7 +24,7 @@ SOFTWARE.
 
 #pragma once
 
-#include "promise.h"
+#include "core.h"
 
 #include <stdexcept>
 

--- a/include/promise/core/Handle.h
+++ b/include/promise/core/Handle.h
@@ -68,25 +68,6 @@ protected:
    using ValuePromise = ValuePromise<T>;
    /** @brief Lock guard type for shared mutex synchronization. */
    using Locker = std::unique_lock<std::shared_mutex>;
-   /**
-    * @brief Unlock helper for lock guards.
-    */
-   struct Unlock {
-      /** @brief Reference to the lock being managed. */
-      Locker& lock_;
-
-      /**
-       * @brief Unlock the lock on destruction.
-       */
-#if defined(__clang__)
-      __attribute__((no_sanitize("address")))
-#endif
-      ~Unlock() {
-         if (lock_) {
-            lock_.unlock();
-         }
-      }
-   };
 
    /**
     * @brief Returned promise type for this handle.

--- a/include/promise/core/Promise.h
+++ b/include/promise/core/Promise.h
@@ -89,8 +89,6 @@ protected:
    using handle_type = Handle<T, WITH_RESOLVER>::handle_type;
    /** @brief Lock guard type for shared mutex synchronization. */
    using Locker = typename Handle<T, WITH_RESOLVER>::Locker;
-   /** @brief Unlock helper for lock guards. */
-   using Unlock = typename Handle<T, WITH_RESOLVER>::Unlock;
 
    /** @brief Boolean constant indicating whether this is a void promise. */
    static constexpr bool IS_VOID = std::is_void_v<T>;
@@ -402,7 +400,7 @@ public:
     * @brief Create a promise from a callable and optional resolver.
     **
     * @tparam RPROMISE Boolean flag indicating whether to return a tuple with resolver and
-    *rejector.
+    *           rejector.
     * @tparam FUN Type of the callable.
     * @tparam ARGS Types of arguments to forward to the callable.
     **
@@ -424,6 +422,31 @@ public:
      details::WPromise<T>> Create(FUN&& func, ARGS&&... args);
 
 private:
+   /**
+    * @brief Create a promise from a callable and optional resolver.
+    **
+    * @tparam RPROMISE Boolean flag indicating whether to return a tuple with resolver and
+    *           rejector.
+    * @tparam FUN Type of the callable.
+    * @tparam ARGS Types of arguments to forward to the callable.
+    **
+    * @param func Callable used to produce the promise.
+    * @param args Arguments forwarded to the callable.
+    *
+    * @return Promise or tuple when RPROMISE is true.
+    */
+   template <bool RPROMISE, class FUN, class... ARGS>
+#if defined(__clang__)
+   __attribute__((no_sanitize("address")))
+#endif
+   static constexpr std::conditional_t<
+     RPROMISE,
+     std::tuple<
+       details::WPromise<T>,
+       std::shared_ptr<promise::Resolve<T>>,
+       std::shared_ptr<promise::Reject>>,
+     details::WPromise<T>> CreateImpl(FUN&& func, ARGS&&... args);
+
    std::atomic<std::size_t> use_count_{0};
    struct AwaitFunction : std::function<void()> {
       std::size_t id_{0};

--- a/include/promise/core/WPromise.h
+++ b/include/promise/core/WPromise.h
@@ -192,6 +192,8 @@ public:
     *
     * @warning Undefined if called before resolution.
     */
+   template <class...>
+      requires(!std::is_void_v<T>)
    [[nodiscard]] cref_or_void_t<T> Value() const noexcept;
 
    /**
@@ -385,6 +387,52 @@ private:
     * @param details Shared promise state.
     */
    WPromise(Details details);
+
+   /**
+    * @brief Chain a continuation to run on resolve.
+    *
+    * @tparam FUN Type of the continuation function.
+    * @tparam ARGS Types of arguments to forward to the continuation.
+    *
+    * @param func Continuation to invoke on resolve.
+    * @param args Arguments forwarded to the continuation.
+    *
+    * @return Chained promise.
+    * @note Best practice: store the returned promise or call Detach().
+    */
+   template <class FUN, class SELF, class... ARGS>
+   [[nodiscard("Either store this promise or call Detach()")]] constexpr ThenReturn<FUN>
+   ThenImpl(this SELF&& self, FUN&& func, ARGS&&... args);
+
+   /**
+    * @brief Chain a continuation to run on rejection.
+    *
+    * @tparam FUN Type of the continuation function.
+    * @tparam ARGS Types of arguments to forward to the continuation.
+    *
+    * @param func Continuation to invoke on rejection.
+    * @param args Arguments forwarded to the continuation.
+    *
+    * @return Chained promise.
+    * @note Best practice: store the returned promise or call Detach().
+    */
+   template <class FUN, class SELF, class... ARGS>
+   [[nodiscard("Either store this promise or call Detach()")]] constexpr CatchReturn<T, FUN>
+   CatchImpl(this SELF&& self, FUN&& func, ARGS&&... args);
+
+   /**
+    * @brief Chain a continuation that runs regardless of outcome.
+    *
+    * @tparam FUN Type of the continuation function.
+    *
+    * @param func Continuation to invoke after resolve or reject.
+    *
+    * @return Chained promise.
+    * @note Best practice: store the returned promise or call Detach().
+    */
+   template <class FUN, class SELF>
+   [[nodiscard("Either store this promise or call Detach()")]] constexpr FinallyReturn<T>
+   FinallyImpl(this SELF&& self, FUN&& func);
 
    template <class, bool>
    friend class IPromise;

--- a/include/promise/details/Promise.inl
+++ b/include/promise/details/Promise.inl
@@ -25,6 +25,7 @@ SOFTWARE.
 #pragma once
 
 #include "../core/Promise.h"
+#include "../core/concepts.inl"
 
 #include <cassert>
 #include <exception>
@@ -281,6 +282,11 @@ template <class T, bool WITH_RESOLVER>
 template <class FUN, class... ARGS>
 [[nodiscard]] constexpr ThenReturn<FUN>
 Promise<T, WITH_RESOLVER>::Then(FUN&& func, ARGS&&... args) & {
+   static_assert(
+     !function_constructible<FUN> || IS_FUNCTION<FUN>,
+     "Then std::function shall have been explicitly specified."
+   );
+
    if (std::unique_lock ulock{this->mutex_}; this->IsDone(ulock)) {
       ulock.unlock();
       std::shared_lock lock{this->mutex_};
@@ -460,6 +466,11 @@ template <class T, bool WITH_RESOLVER>
 template <class FUN, class... ARGS>
 [[nodiscard]] constexpr ThenReturn<FUN>
 Promise<T, WITH_RESOLVER>::Then(std::shared_ptr<Promise>&& self, FUN&& func, ARGS&&... args) && {
+   static_assert(
+     !function_constructible<FUN> || IS_FUNCTION<FUN>,
+     "Then std::function shall have been explicitly specified."
+   );
+
    assert(self);
    ScopeExit _{[&]() { std::move(*this).Detach(std::move(self)); }};
    return self->Then(std::forward<FUN>(func), std::forward<ARGS>(args)...);
@@ -480,6 +491,11 @@ template <class T, bool WITH_RESOLVER>
 template <class FUN, class... ARGS>
 [[nodiscard]] constexpr CatchReturn<T, FUN>
 Promise<T, WITH_RESOLVER>::Catch(FUN&& func, ARGS&&... args) & {
+   static_assert(
+     !function_constructible<FUN> || IS_FUNCTION<FUN>,
+     "Catch std::function shall have been explicitly specified."
+   );
+
    // Promise return type
    using promise_t = return_t<decltype(std::function{func})>;
    using T2 = std::conditional_t<IS_PROMISE_FUNCTION<FUN>, return_or_void_t<promise_t>, promise_t>;
@@ -492,7 +508,11 @@ Promise<T, WITH_RESOLVER>::Catch(FUN&& func, ARGS&&... args) & {
 
    using ReturnType = return_t<CatchReturn<T, FUN>>;
 
-   auto apply_value = [this](auto& lock) constexpr {
+   auto apply_value =
+     [this](auto& lock) constexpr -> std::conditional_t<
+                                    std::is_void_v<T>,
+                                    std::conditional_t<std::is_void_v<T2>, void, std::optional<T2>>,
+                                    cref_or_void_t<T>> {
       if constexpr (std::is_void_v<T>) {
          (void)this;
          lock.unlock();
@@ -570,8 +590,8 @@ Promise<T, WITH_RESOLVER>::Catch(FUN&& func, ARGS&&... args) & {
    };
 
    auto [promise, resolve, reject] = promise::Create<ReturnType>();
-   try {
-      if (std::unique_lock ulock{this->mutex_}; this->IsDone(ulock)) {
+   if (std::unique_lock ulock{this->mutex_}; this->IsDone(ulock)) {
+      try {
          ulock.unlock();
          std::shared_lock lock{this->mutex_};
 
@@ -602,64 +622,64 @@ Promise<T, WITH_RESOLVER>::Catch(FUN&& func, ARGS&&... args) & {
          } else {
             (*resolve)(apply_value(lock));
          }
-      } else {
-         Await(
-           [this,
-            resolve         = std::move(resolve),
-            reject          = std::move(reject),
-            apply_exception = std::move(apply_exception),
-            apply_value     = std::move(apply_value),
-            resolve_wrapper = std::move(resolve_wrapper),
-            ... args        = std::forward<ARGS>(args)] constexpr mutable {
-              std::shared_lock lock{this->mutex_};
-              auto const&      exception = this->GetException(lock);
+      } catch (...) {
+         (*reject)(std::current_exception());
+      }
+   } else {
+      Await(
+        [this,
+         resolve         = std::move(resolve),
+         reject          = std::move(reject),
+         apply_exception = std::move(apply_exception),
+         apply_value     = std::move(apply_value),
+         resolve_wrapper = std::move(resolve_wrapper),
+         ... args        = std::forward<ARGS>(args)] constexpr mutable {
+           std::shared_lock lock{this->mutex_};
+           auto const&      exception = this->GetException(lock);
 
-              try {
-                 if (exception) {
-                    lock.unlock();
+           try {
+              if (exception) {
+                 lock.unlock();
 
-                    if constexpr (IS_PROMISE_FUNCTION<FUN>) {
-                       resolve_wrapper(apply_exception(exception), std::move(resolve))
-                         .Catch([reject = std::move(reject)](std::exception_ptr exception) {
-                            (*reject)(std::move(exception));
-                         })
-                         .Detach();
-                    } else {
-                       (void)resolve_wrapper;
-
-                       if constexpr (
-                         std::is_void_v<
-                           std::invoke_result_t<decltype(apply_exception), decltype(exception)>>
-                       ) {
-                          apply_exception(exception);
-                          (*resolve)();
-                       } else {
-                          (*resolve)(apply_exception(exception));
-                       }
-                    }
+                 if constexpr (IS_PROMISE_FUNCTION<FUN>) {
+                    resolve_wrapper(apply_exception(exception), std::move(resolve))
+                      .Catch([reject = std::move(reject)](std::exception_ptr exception) {
+                         (*reject)(std::move(exception));
+                      })
+                      .Detach();
                  } else {
+                    (void)resolve_wrapper;
+
                     if constexpr (
-                      std::is_void_v<std::invoke_result_t<decltype(apply_value), decltype((lock))>>
+                      std::is_void_v<
+                        std::invoke_result_t<decltype(apply_exception), decltype(exception)>>
                     ) {
-                       apply_value(lock);
+                       apply_exception(exception);
                        (*resolve)();
                     } else {
-                       (*resolve)(apply_value(lock));
+                       (*resolve)(apply_exception(exception));
                     }
                  }
-              } catch (...) {
-                 if (lock.owns_lock()) {
-                    lock.unlock();
+              } else {
+                 if constexpr (
+                   std::is_void_v<std::invoke_result_t<decltype(apply_value), decltype((lock))>>
+                 ) {
+                    apply_value(lock);
+                    (*resolve)();
+                 } else {
+                    (*resolve)(apply_value(lock));
                  }
-
-                 (*reject)(std::current_exception());
               }
-           },
-           ulock
-         );
-      }
-   } catch (...) {
-      (*reject)(std::current_exception());
+           } catch (...) {
+              if (lock.owns_lock()) {
+                 lock.unlock();
+              }
+
+              (*reject)(std::current_exception());
+           }
+        },
+        ulock
+      );
    }
 
    return std::move(promise);
@@ -681,6 +701,11 @@ template <class T, bool WITH_RESOLVER>
 template <class FUN, class... ARGS>
 [[nodiscard]] constexpr CatchReturn<T, FUN>
 Promise<T, WITH_RESOLVER>::Catch(std::shared_ptr<Promise>&& self, FUN&& func, ARGS&&... args) && {
+   static_assert(
+     !function_constructible<FUN> || IS_FUNCTION<FUN>,
+     "Catch std::function shall have been explicitly specified."
+   );
+
    assert(self);
    ScopeExit _{[&]() { std::move(*this).Detach(std::move(self)); }};
    return self->Catch(std::forward<FUN>(func), std::forward<ARGS>(args)...);
@@ -700,6 +725,11 @@ template <class T, bool WITH_RESOLVER>
 template <class FUN, class... ARGS>
 [[nodiscard]] constexpr FinallyReturn<T>
 Promise<T, WITH_RESOLVER>::Finally(FUN&& func) & {
+   static_assert(
+     !function_constructible<FUN> || IS_FUNCTION<FUN>,
+     "Finally std::function shall have been explicitly specified."
+   );
+
    auto apply_value = [](auto&& resolve, auto&& reject, auto&& func, auto&&... value) constexpr {
       static_assert(sizeof...(value) == (IS_VOID ? 0 : 1));
 
@@ -713,10 +743,12 @@ Promise<T, WITH_RESOLVER>::Finally(FUN&& func) & {
               })
               .Detach();
          } else {
+            static_assert(sizeof...(value) == 1);
+
             MakePromise(std::forward<FUN>(func))
-              .Then([resolve = std::move(resolve),
-                     value   = std::tuple{std::forward<decltype(value)>(value)...}]() constexpr {
-                 (*resolve)(std::get<0>(value));
+              .Then([resolve   = std::move(resolve),
+                     ... value = std::forward<decltype(value)>(value)]() constexpr {
+                 (*resolve)(value...);
               })
               .Catch([reject =
                         std::forward<decltype(reject)>(reject)](std::exception_ptr exception) {
@@ -789,8 +821,9 @@ Promise<T, WITH_RESOLVER>::Finally(FUN&& func) & {
          apply_value     = std::move(apply_value)] constexpr mutable {
            std::shared_lock lock{this->mutex_};
            auto const&      exception = this->GetException(lock);
-
+#ifndef NO_COVERAGE
            try {
+#endif
               if (exception) {
                  lock.unlock();
                  apply_exception(reject, std::move(func), exception);
@@ -803,7 +836,8 @@ Promise<T, WITH_RESOLVER>::Finally(FUN&& func) & {
 
                  apply_value(std::move(resolve), reject, std::move(func), value);
               }
-           } catch (...) {  // GCOVR_EXCL_START
+#ifndef NO_COVERAGE
+           } catch (...) {
               assert(
                 false
                 && "This shall not throw since we're already handling "
@@ -816,7 +850,8 @@ Promise<T, WITH_RESOLVER>::Finally(FUN&& func) & {
               }
 
               (*reject)(std::current_exception());
-           }  // GCOVR_EXCL_STOP
+           }
+#endif
         },
         ulock
       );
@@ -839,6 +874,11 @@ template <class T, bool WITH_RESOLVER>
 template <class FUN>
 [[nodiscard]] constexpr FinallyReturn<T>
 Promise<T, WITH_RESOLVER>::Finally(std::shared_ptr<Promise>&& self, FUN&& func) && {
+   static_assert(
+     !function_constructible<FUN> || IS_FUNCTION<FUN>,
+     "Finally std::function shall have been explicitly specified."
+   );
+
    assert(self);
    ScopeExit _{[&]() { std::move(*this).Detach(std::move(self)); }};
    return self->Finally(std::forward<FUN>(func));
@@ -1053,6 +1093,47 @@ constexpr std::conditional_t<
     std::shared_ptr<promise::Reject>>,
   details::WPromise<T>>
 Promise<T, WITH_RESOLVER>::Create(FUN&& func, ARGS&&... args) {
+   // Normalize lambdas and functors into a single type to reduce instantiations
+
+   if constexpr (!IS_FUNCTION<FUN> && function_constructible<FUN>) {
+      return CreateImpl<RPROMISE>(
+        std::function{std::forward<FUN>(func)}, std::forward<ARGS>(args)...
+      );
+   } else {
+      return CreateImpl<RPROMISE>(std::forward<FUN>(func), std::forward<ARGS>(args)...);
+   }
+}
+
+/**
+ * @brief Create a promise from a callable and optional resolver.
+ **
+ * @tparam RPROMISE Boolean flag indicating whether to return a tuple with
+ *             resolver and rejector.
+ * @tparam FUN Type of the callable.
+ * @tparam ARGS Types of arguments to forward to the callable.
+ **
+ * @param func Callable used to produce the promise.
+ * @param args Arguments forwarded to the callable.
+ *
+ * @return Promise or tuple when RPROMISE is true.
+ */
+template <class T, bool WITH_RESOLVER>
+template <bool RPROMISE, class FUN, class... ARGS>
+#if defined(__clang__)
+__attribute__((no_sanitize("address")))
+#endif
+constexpr std::conditional_t<
+  RPROMISE,
+  std::tuple<
+    details::WPromise<T>,
+    std::shared_ptr<promise::Resolve<T>>,
+    std::shared_ptr<promise::Reject>>,
+  details::WPromise<T>>
+Promise<T, WITH_RESOLVER>::CreateImpl(FUN&& func, ARGS&&... args) {
+   static_assert(
+     !function_constructible<FUN> || IS_FUNCTION<FUN>,
+     "Create std::function shall have been explicitly specified."
+   );
    static_assert(
      IS_PROMISE_FUNCTION<FUN>,
      "Create only supports callables that return promises, not "

--- a/include/promise/details/WPromise.inl
+++ b/include/promise/details/WPromise.inl
@@ -244,6 +244,8 @@ WPromise<T>::Resolved() const noexcept {
  * @warning Undefined if called before resolution.
  */
 template <class T>
+template <class...>
+   requires(!std::is_void_v<T>)
 [[nodiscard]] cref_or_void_t<T>
 WPromise<T>::Value() const noexcept {
    return std::visit(
@@ -362,6 +364,39 @@ template <class T>
 template <class FUN, class SELF, class... ARGS>
 [[nodiscard("Either store this promise or call Detach()")]] constexpr ThenReturn<FUN>
 WPromise<T>::Then(this SELF&& self, FUN&& func, ARGS&&... args) {
+   // Normalize lambdas and functors into a single type to reduce instantiations
+
+   if constexpr (!IS_FUNCTION<FUN> && function_constructible<FUN>) {
+      return std::forward<SELF>(self).ThenImpl(
+        std::function{std::forward<FUN>(func)}, std::forward<ARGS>(args)...
+      );
+   } else {
+      return std::forward<SELF>(self).ThenImpl(
+        std::forward<FUN>(func), std::forward<ARGS>(args)...
+      );
+   }
+}
+
+/**
+ * @brief Chain a continuation to run on resolve.
+ *
+ * @tparam FUN Type of the continuation function.
+ * @tparam ARGS Types of arguments to forward to the continuation.
+ *
+ * @param func Continuation to invoke on resolve.
+ * @param args Arguments forwarded to the continuation.
+ *
+ * @return Chained promise.
+ * @note Best practice: store the returned promise or call Detach().
+ */
+template <class T>
+template <class FUN, class SELF, class... ARGS>
+[[nodiscard("Either store this promise or call Detach()")]] constexpr ThenReturn<FUN>
+WPromise<T>::ThenImpl(this SELF&& self, FUN&& func, ARGS&&... args) {
+   static_assert(
+     !function_constructible<FUN> || IS_FUNCTION<FUN>,
+     "Then std::function shall have been explicitly specified."
+   );
    return std::visit(
      [&](auto&& details) constexpr {
         assert(details);
@@ -395,6 +430,39 @@ template <class T>
 template <class FUN, class SELF, class... ARGS>
 [[nodiscard("Either store this promise or call Detach()")]] constexpr CatchReturn<T, FUN>
 WPromise<T>::Catch(this SELF&& self, FUN&& func, ARGS&&... args) {
+   // Normalize lambdas and functors into a single type to reduce instantiations
+
+   if constexpr (!IS_FUNCTION<FUN> && function_constructible<FUN>) {
+      return std::forward<SELF>(self).CatchImpl(
+        std::function{std::forward<FUN>(func)}, std::forward<ARGS>(args)...
+      );
+   } else {
+      return std::forward<SELF>(self).CatchImpl(
+        std::forward<FUN>(func), std::forward<ARGS>(args)...
+      );
+   }
+}
+
+/**
+ * @brief Chain a continuation to run on rejection.
+ *
+ * @tparam FUN Type of the continuation function.
+ * @tparam ARGS Types of arguments to forward to the continuation.
+ *
+ * @param func Continuation to invoke on rejection.
+ * @param args Arguments forwarded to the continuation.
+ *
+ * @return Chained promise.
+ * @note Best practice: store the returned promise or call Detach().
+ */
+template <class T>
+template <class FUN, class SELF, class... ARGS>
+[[nodiscard("Either store this promise or call Detach()")]] constexpr CatchReturn<T, FUN>
+WPromise<T>::CatchImpl(this SELF&& self, FUN&& func, ARGS&&... args) {
+   static_assert(
+     !function_constructible<FUN> || IS_FUNCTION<FUN>,
+     "Catch std::function shall have been explicitly specified."
+   );
    return std::visit(
      [&](auto&& details) constexpr {
         assert(details);
@@ -426,6 +494,33 @@ template <class T>
 template <class FUN, class SELF>
 [[nodiscard("Either store this promise or call Detach()")]] constexpr FinallyReturn<T>
 WPromise<T>::Finally(this SELF&& self, FUN&& func) {
+   // Normalize lambdas and functors into a single type to reduce instantiations
+
+   if constexpr (!IS_FUNCTION<FUN> && function_constructible<FUN>) {
+      return std::forward<SELF>(self).FinallyImpl(std::function{std::forward<FUN>(func)});
+   } else {
+      return std::forward<SELF>(self).FinallyImpl(std::forward<FUN>(func));
+   }
+}
+
+/**
+ * @brief Chain a continuation that runs regardless of outcome.
+ *
+ * @tparam FUN Type of the continuation function.
+ *
+ * @param func Continuation to invoke after resolve or reject.
+ *
+ * @return Chained promise.
+ * @note Best practice: store the returned promise or call Detach().
+ */
+template <class T>
+template <class FUN, class SELF>
+[[nodiscard("Either store this promise or call Detach()")]] constexpr FinallyReturn<T>
+WPromise<T>::FinallyImpl(this SELF&& self, FUN&& func) {
+   static_assert(
+     !function_constructible<FUN> || IS_FUNCTION<FUN>,
+     "Finally std::function shall have been explicitly specified."
+   );
    return std::visit(
      [&](auto&& details) constexpr {
         assert(details);

--- a/src/StatePromise.cpp
+++ b/src/StatePromise.cpp
@@ -23,6 +23,9 @@ SOFTWARE.
 */
 
 #include "StatePromise.h"
+
+#include "promise.h"
+
 #include <cassert>
 
 /** @brief Constructs a new StatePromise with a fresh promise state. */

--- a/test/Promise/DeepBranches.cpp
+++ b/test/Promise/DeepBranches.cpp
@@ -180,14 +180,6 @@ TEST_CASE("Detail promise VAwait allocates erased awaitable", "[Promise][DeepBra
    });
 }
 
-TEST_CASE("Internal Unlock guard releases the mutex on scope exit", "[Promise][DeepBranches]") {
-   RunWithTimeout(2s, [&] {
-      auto resolved_detail = TestHelper::Create<int, false>();
-
-      REQUIRE(TestHelper::ExerciseUnlock(*resolved_detail));
-   });
-}
-
 TEST_CASE("Rejected void promise catch resolves through void handler", "[Promise][DeepBranches]") {
    RunWithTimeout(2s, [&] {
       auto promise   = Promise<void>::Reject<TestError>("rejected void");

--- a/test/TestCommon.h
+++ b/test/TestCommon.h
@@ -10,6 +10,7 @@
 #include <promise/MessageQueue.h>
 #include <promise/Pool.h>
 #include <promise/StatePromise.h>
+#include <promise/promise.h>
 
 #include <chrono>
 #include <exception>
@@ -184,20 +185,6 @@ struct Test {
    }
 
    template <class T, bool WITH_RESOLVER>
-   static bool ExerciseUnlock(promise::details::Promise<T, WITH_RESOLVER>& promise) {
-      std::unique_lock lock{promise.mutex_};
-      using Unlock = typename details::Promise<T, WITH_RESOLVER>::Unlock;
-
-      {
-         Unlock unlock{lock};
-         (void)unlock;
-         REQUIRE(lock.owns_lock());
-      }
-
-      return !lock.owns_lock();
-   }
-
-   template <class T, bool WITH_RESOLVER>
    static std::size_t Awaiters(promise::details::Promise<T, WITH_RESOLVER> const& promise) {
       return promise.Awaiters();
    }
@@ -281,18 +268,18 @@ struct Test {
    template <class T, bool WITH_RESOLVER, class FUN, class... ARGS>
    static auto
    Then(promise::details::Promise<T, WITH_RESOLVER>& promise, FUN&& func, ARGS&&... args) {
-      return promise.Then(std::forward<FUN>(func), std::forward<ARGS>(args)...);
+      return promise.Then(std::function{std::forward<FUN>(func)}, std::forward<ARGS>(args)...);
    }
 
    template <class T, bool WITH_RESOLVER, class FUN, class... ARGS>
    static auto
    Catch(promise::details::Promise<T, WITH_RESOLVER>& promise, FUN&& func, ARGS&&... args) {
-      return promise.Catch(std::forward<FUN>(func), std::forward<ARGS>(args)...);
+      return promise.Catch(std::function{std::forward<FUN>(func)}, std::forward<ARGS>(args)...);
    }
 
    template <class T, bool WITH_RESOLVER, class FUN>
    static auto Finally(promise::details::Promise<T, WITH_RESOLVER>& promise, FUN&& func) {
-      return promise.Finally(std::forward<FUN>(func));
+      return promise.Finally(std::function{std::forward<FUN>(func)});
    }
 };
 }  // namespace promise


### PR DESCRIPTION
- Eliminated leftover UnLock struct.
- Added early conversion of continuation lambdas into std::function when possible → avoids generating multiple Then/Catch/Finally/Create instantiations for identical signatures → reduces template bloat and improves compile time